### PR TITLE
fix: server list forwarding from settings

### DIFF
--- a/src/OpenApiGenerator.ts
+++ b/src/OpenApiGenerator.ts
@@ -83,7 +83,7 @@ export class OpenApiGenerator {
         const document: OpenAPIV3_1.Document & { servers: Array<OpenAPIV3_1.ServerObject> } = {
             openapi: `${openApiVersion}.0`,
             ...this.document,
-            servers: [],
+					  servers: this.document.servers ?? [],
             tags: [],
             components: this.cleanComponents(this.document.components)
         };

--- a/src/OpenApiGenerator.ts
+++ b/src/OpenApiGenerator.ts
@@ -83,7 +83,7 @@ export class OpenApiGenerator {
         const document: OpenAPIV3_1.Document & { servers: Array<OpenAPIV3_1.ServerObject> } = {
             openapi: `${openApiVersion}.0`,
             ...this.document,
-					  servers: this.document.servers ?? [],
+            servers: this.document.servers ?? [],
             tags: [],
             components: this.cleanComponents(this.document.components)
         };


### PR DESCRIPTION
By default, the server list was overwritten by the servers: [] field, preventing user-defined servers from being added to the output.